### PR TITLE
履歴のViewを追加・成功、失敗のアイコン追加

### DIFF
--- a/Mahjong-seiseki-sender/ApiClient.swift
+++ b/Mahjong-seiseki-sender/ApiClient.swift
@@ -23,6 +23,7 @@ class ApiClient {
     }
 
     func saveResults(gameResult: GameResult, completion: @escaping (Result<GeneralResponse, AFError>) -> ()) {
+        // TODO: 置き場を変える
         let url = "https://script.google.com/macros/s/AKfycbyRXnQvRbece1glMCLM_w_MCpTeMr5m4EU2gmd6c5A2ZwP9xnKA7e9RcRtHpXYJdxNghg/exec"
 
         let request = session.request(

--- a/Mahjong-seiseki-sender/ContentView.swift
+++ b/Mahjong-seiseki-sender/ContentView.swift
@@ -15,6 +15,7 @@ struct ContentView: View {
     @State var results: [GameResult] = []
 
     @State var isSending = false
+    @State private var showingResetAlert = false
 
     var body: some View {
         VStack {
@@ -154,11 +155,24 @@ struct ContentView: View {
         }
     }
     
+    // リセットボタン
     private var resetButton: some View {
-        Button(action: {}, label: {
+        Button(action: {
+            showingResetAlert = true
+        }, label: {
             Text("Reset")
                 .foregroundColor(.red)
         })
+        .alert("確認", isPresented: $showingResetAlert) {
+            Button("キャンセル", role: .cancel) {
+                // do nothing
+            }
+            Button("削除", role: .destructive) {
+                results.removeAll()
+            }
+        } message: {
+            Text("全てのデータを削除しますか？\n削除しても送信した先のデータが消えることはありません。")
+        }
     }
 }
 

--- a/Mahjong-seiseki-sender/ContentView.swift
+++ b/Mahjong-seiseki-sender/ContentView.swift
@@ -14,11 +14,7 @@ struct ContentView: View {
     @State var rank = Rank.first
     @State var point: Float = 0.0
     @State var rule = Rule.M_REAGUE
-    @State var results: [GameResult] = [
-        GameResult(timeStamp: Date(), description: "1戦目", point: Point(value: 33.4), rank: Rank.first, rule: Rule.KYOKAI),
-        GameResult(timeStamp: Date(), description: "2戦目", point: Point(value: 33.4), rank: Rank.second, rule: Rule.SAIKOUISEN),
-        GameResult(timeStamp: Date(), description: "3戦目", point: Point(value: -33.4), rank: Rank.third, rule: Rule.RENMEI)
-    ]
+    @State var results: [GameResult] = []
 
     @State var isSending = false
 
@@ -30,7 +26,8 @@ struct ContentView: View {
         .padding()
     }
     
-    /// 入力欄
+    // TODO: 各セクション毎くらいに別ファイルに切り出す
+    /// 入力セクション
     private var inputSection: some View {
         VStack {
             descriptionInput
@@ -39,6 +36,26 @@ struct ContentView: View {
             ruleInput
             sendButton
         }
+    }
+    
+    // ログを表示するセクション
+    private var resultListSection: some View {
+        List {
+            ForEach(results, id: \.timeStamp) { result in
+                HStack {
+                    Text(result.timeStamp.format())
+                    Text(result.rule.shortHanded)
+                    Spacer()
+                    Text(result.rank.toString())
+                    Text(result.point.value > 0 ? "+" + String(format: "%.1f", round(result.point.value * 10) / 10) : String(format: "%.1f", round(result.point.value * 10) / 10))
+                }
+            }
+        }
+        .listStyle(.plain)
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color(red: 200/255, green: 200/255, blue: 200/255), lineWidth: 2)
+        )
     }
     
     /// 説明欄
@@ -97,16 +114,21 @@ struct ContentView: View {
         HStack {
             Button(action: {
                 isSending = true
+                let addingResult = GameResult(
+                    timeStamp: Date(),
+                    description: description,
+                    point: Point(value: point),
+                    rank: rank,
+                    rule: rule
+                )
                 ApiClient.shared.saveResults(
-                    gameResult: GameResult(
-                        timeStamp: Date(),
-                        description: description,
-                        point: Point(value: point),
-                        rank: rank,
-                        rule: rule
-                    )
+                    gameResult: addingResult
                 ) { _ in
+                    // ぐるぐるを引っ込める
                     isSending = false
+                    // 履歴viewに追加する
+                    // TODO: 切り出す
+                    results.append(addingResult)
                 }
             }, label: {
                 Text("Send")
@@ -116,25 +138,6 @@ struct ContentView: View {
                 ProgressView().progressViewStyle(.circular)
             }
         }
-    }
-    
-    private var resultListSection: some View {
-        List {
-            ForEach(results, id: \.timeStamp) { result in
-                HStack {
-                    Text(result.timeStamp.format())
-                    Text(result.rule.shortHanded)
-                    Spacer()
-                    Text(result.rank.toString())
-                    Text(result.point.value > 0 ? "+" + String(format: "%.1f", round(result.point.value * 10) / 10) : String(format: "%.1f", round(result.point.value * 10) / 10))
-                }
-            }
-        }
-        .listStyle(.plain)
-        .overlay(
-            RoundedRectangle(cornerRadius: 10)
-                .stroke(Color(red: 200/255, green: 200/255, blue: 200/255), lineWidth: 2)
-        )
     }
 }
 

--- a/Mahjong-seiseki-sender/ContentView.swift
+++ b/Mahjong-seiseki-sender/ContentView.swift
@@ -7,8 +7,6 @@
 
 import SwiftUI
 
-// TODO: 送信ボタンでAPIを叩ける様にする
-
 struct ContentView: View {
     @State var description = "テスト"
     @State var rank = Rank.first

--- a/Mahjong-seiseki-sender/ContentView.swift
+++ b/Mahjong-seiseki-sender/ContentView.swift
@@ -15,92 +15,126 @@ struct ContentView: View {
     @State var point: Float = 0.0
     @State var rule = Rule.M_REAGUE
     @State var results: [GameResult] = [
-        GameResult(timeStamp: Date(), description: "1戦目", point: 33.4, rank: Rank.first, rule: Rule.KYOKAI),
-        GameResult(timeStamp: Date(), description: "2戦目", point: 33.4, rank: Rank.second, rule: Rule.SAIKOUISEN),
-        GameResult(timeStamp: Date(), description: "3戦目", point: -33.4, rank: Rank.first, rule: Rule.RENMEI)
+        GameResult(timeStamp: Date(), description: "1戦目", point: Point(value: 33.4), rank: Rank.first, rule: Rule.KYOKAI),
+        GameResult(timeStamp: Date(), description: "2戦目", point: Point(value: 33.4), rank: Rank.second, rule: Rule.SAIKOUISEN),
+        GameResult(timeStamp: Date(), description: "3戦目", point: Point(value: -33.4), rank: Rank.third, rule: Rule.RENMEI)
     ]
 
     @State var isSending = false
 
     var body: some View {
         VStack {
-            HStack {
-                Text("description")
-                Text("*").foregroundColor(.red)
-                TextField("例: ベルバードリーグ", text: $description).frame(maxWidth: .infinity, alignment: .trailing).multilineTextAlignment(.trailing)
-            }
-
-            HStack {
-                Text("point")
-                Text("*").foregroundColor(.red)
-                TextField("5桁の数字 例: 12300", value: $point, format: .number).frame(maxWidth: .infinity, alignment: .trailing).multilineTextAlignment(.trailing).keyboardType(.decimalPad)
-            }
-
-            // TODO: スペース管理、幅をもう少し小さくしたい
-            HStack {
-                Text("rank")
-                Text("*").foregroundColor(.red)
-                Spacer()
-                Picker("順位", selection: $rank) {
-                    ForEach(Rank.allCases) {
-                        Text("\($0.rawValue)").tag($0)
-                    }
-                }.pickerStyle(.segmented)
-            }
-
-            HStack {
-                Text("rule")
-                Text("*").foregroundColor(.red)
-                Picker("", selection: $rule) {
-                    ForEach(Rule.allCases) {
-                        Text("\($0.rawValue)").tag($0)
-                    }
-                }.pickerStyle(.wheel)
-            }
-
-            // TODO: ボタンを押したらレスポンスに合わせてOK/NGなUIを出す (コンタクト登録時に出るアレみたいな)
-            // TODO: validate
-            HStack {
-                Button(action: {
-                    isSending = true
-                    ApiClient.shared.saveResults(
-                        gameResult: GameResult(
-                            timeStamp: Date(),
-                            description: description,
-                            point: point,
-                            rank: rank,
-                            rule: rule
-                        )
-                    ) { _ in
-                        isSending = false
-                    }
-                }, label: {
-                    Text("Send")
-                })
-
-                if (isSending) {
-                    ProgressView().progressViewStyle(.circular)
-                }
-            }
-            
-            List {
-                ForEach(results) { result in
-                    HStack {
-                        Text(result.timeStamp.format())
-                        Text(result.rule.rawValue)
-                        Spacer()
-                        Text(result.rank.toString())
-                        Text("\(result.point)")
-                    }
-                }
-            }
-            .listStyle(.plain)
-            .overlay(
-                RoundedRectangle(cornerRadius: 10)
-                    .stroke(Color(red: 200/255, green: 200/255, blue: 200/255), lineWidth: 2)
-            )
+            inputSection
+            resultListSection
         }
         .padding()
+    }
+    
+    /// 入力欄
+    private var inputSection: some View {
+        VStack {
+            descriptionInput
+            pointInput
+            rankInput
+            ruleInput
+            sendButton
+        }
+    }
+    
+    /// 説明欄
+    private var descriptionInput: some View {
+        HStack {
+            Text("description")
+            Text("*").foregroundColor(.red)
+            TextField("例: ベルバードリーグ", text: $description)
+                .frame(maxWidth: .infinity, alignment: .trailing)
+                .multilineTextAlignment(.trailing)
+        }
+    }
+    
+    /// ポイントの入力欄
+    private var pointInput: some View {
+        HStack {
+            Text("point")
+            Text("*").foregroundColor(.red)
+            TextField("5桁の数字 例: 12300", value: $point, format: .number)
+                .frame(maxWidth: .infinity, alignment: .trailing)
+                .multilineTextAlignment(.trailing)
+                .keyboardType(.decimalPad)
+        }
+    }
+    
+    /// 順位の入力欄
+    private var rankInput: some View {
+        HStack {
+            Text("rank")
+            Text("*").foregroundColor(.red)
+            Spacer()
+            Picker("順位", selection: $rank) {
+                ForEach(Rank.allCases) {
+                    Text("\($0.rawValue)").tag($0)
+                }
+            }.pickerStyle(.segmented)
+        }
+    }
+    
+    /// ルールの入力欄(ドラム)
+    private var ruleInput: some View {
+        HStack {
+            Text("rule")
+            Text("*").foregroundColor(.red)
+            Picker("", selection: $rule) {
+                ForEach(Rule.allCases) {
+                    Text("\($0.rawValue)").tag($0)
+                }
+            }.pickerStyle(.wheel)
+        }
+    }
+    
+    /// 送信ボタン
+    // TODO: 送信時の処理をUsecase的なところに移植する
+    private var sendButton: some View {
+        HStack {
+            Button(action: {
+                isSending = true
+                ApiClient.shared.saveResults(
+                    gameResult: GameResult(
+                        timeStamp: Date(),
+                        description: description,
+                        point: Point(value: point),
+                        rank: rank,
+                        rule: rule
+                    )
+                ) { _ in
+                    isSending = false
+                }
+            }, label: {
+                Text("Send")
+            })
+
+            if (isSending) {
+                ProgressView().progressViewStyle(.circular)
+            }
+        }
+    }
+    
+    private var resultListSection: some View {
+        List {
+            ForEach(results, id: \.timeStamp) { result in
+                HStack {
+                    Text(result.timeStamp.format())
+                    Text(result.rule.shortHanded)
+                    Spacer()
+                    Text(result.rank.toString())
+                    Text(result.point.value > 0 ? "+" + String(format: "%.1f", round(result.point.value * 10) / 10) : String(format: "%.1f", round(result.point.value * 10) / 10))
+                }
+            }
+        }
+        .listStyle(.plain)
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color(red: 200/255, green: 200/255, blue: 200/255), lineWidth: 2)
+        )
     }
 }
 

--- a/Mahjong-seiseki-sender/ContentView.swift
+++ b/Mahjong-seiseki-sender/ContentView.swift
@@ -12,18 +12,18 @@ import SwiftUI
 struct ContentView: View {
     @State var description = "テスト"
     @State var rank = Rank.first
-    @State var point: Int = 0
+    @State var point: Float = 0.0
     @State var rule = Rule.M_REAGUE
+    @State var results: [GameResult] = [
+        GameResult(timeStamp: Date(), description: "1戦目", point: 33.4, rank: Rank.first, rule: Rule.KYOKAI),
+        GameResult(timeStamp: Date(), description: "2戦目", point: 33.4, rank: Rank.second, rule: Rule.SAIKOUISEN),
+        GameResult(timeStamp: Date(), description: "3戦目", point: -33.4, rank: Rank.first, rule: Rule.RENMEI)
+    ]
 
     @State var isSending = false
 
     var body: some View {
         VStack {
-            Image(systemName: "globe")
-                .imageScale(.large)
-                .foregroundStyle(.tint)
-            Text("Hello, world!")
-
             HStack {
                 Text("description")
                 Text("*").foregroundColor(.red)
@@ -65,9 +65,10 @@ struct ContentView: View {
                     isSending = true
                     ApiClient.shared.saveResults(
                         gameResult: GameResult(
+                            timeStamp: Date(),
                             description: description,
                             point: point,
-                            rank: rank.rawValue,
+                            rank: rank,
                             rule: rule
                         )
                     ) { _ in
@@ -81,6 +82,23 @@ struct ContentView: View {
                     ProgressView().progressViewStyle(.circular)
                 }
             }
+            
+            List {
+                ForEach(results) { result in
+                    HStack {
+                        Text(result.timeStamp.format())
+                        Text(result.rule.rawValue)
+                        Spacer()
+                        Text(result.rank.toString())
+                        Text("\(result.point)")
+                    }
+                }
+            }
+            .listStyle(.plain)
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Color(red: 200/255, green: 200/255, blue: 200/255), lineWidth: 2)
+            )
         }
         .padding()
     }
@@ -88,4 +106,13 @@ struct ContentView: View {
 
 #Preview {
     ContentView()
+}
+
+extension Date {
+    
+    func format() -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yy/MM/dd HH:mm"
+        return formatter.string(from: self)
+    }
 }

--- a/Mahjong-seiseki-sender/ContentView.swift
+++ b/Mahjong-seiseki-sender/ContentView.swift
@@ -32,24 +32,40 @@ struct ContentView: View {
             pointInput
             rankInput
             ruleInput
-            sendButton
+            HStack {
+                Spacer()
+                sendButton
+                Spacer()
+                resetButton
+            }
         }
     }
     
     // ログを表示するセクション
     private var resultListSection: some View {
-        List {
-            ForEach(results, id: \.timeStamp) { result in
-                HStack {
-                    Text(result.timeStamp.format())
-                    Text(result.rule.shortHanded)
-                    Spacer()
-                    Text(result.rank.toString())
-                    Text(result.point.value > 0 ? "+" + String(format: "%.1f", round(result.point.value * 10) / 10) : String(format: "%.1f", round(result.point.value * 10) / 10))
+        VStack {
+            List {
+                ForEach(results, id: \.timeStamp) { result in
+                    HStack {
+                        Text(result.timeStamp.format())
+                        Text(result.rule.shortHanded)
+                        Spacer()
+                        Text(result.rank.toString())
+                        Text(result.point.value > 0 ? "+" + String(format: "%.1f", round(result.point.value * 10) / 10) : String(format: "%.1f", round(result.point.value * 10) / 10))
+                    }
                 }
             }
+            .listStyle(.plain)
+            
+            // 合計ポイントと平均順位を表示するView
+            HStack {
+                Spacer()
+                Text("平均順位: \(String(format: "%.2f", results.map { Double($0.rank.rawValue) }.reduce(0, +) / Double(results.count)))")
+                Text("合計: \(results.map { $0.point.value }.reduce(0, +).signedString)")
+            }
+            .padding()
+            .background(Color(red: 240/255, green: 240/255, blue: 240/255))
         }
-        .listStyle(.plain)
         .overlay(
             RoundedRectangle(cornerRadius: 10)
                 .stroke(Color(red: 200/255, green: 200/255, blue: 200/255), lineWidth: 2)
@@ -137,17 +153,33 @@ struct ContentView: View {
             }
         }
     }
+    
+    private var resetButton: some View {
+        Button(action: {}, label: {
+            Text("Reset")
+                .foregroundColor(.red)
+        })
+    }
 }
 
 #Preview {
     ContentView()
 }
 
+// TODO: 切り出す
 extension Date {
-    
     func format() -> String {
         let formatter = DateFormatter()
         formatter.dateFormat = "yy/MM/dd HH:mm"
         return formatter.string(from: self)
+    }
+}
+
+extension Float {
+    var signedString: String {
+        let formatter = NumberFormatter()
+        formatter.positivePrefix = "+"
+        formatter.negativePrefix = "▲"
+        return formatter.string(from: NSNumber(value: self)) ?? "\(self)"
     }
 }

--- a/Mahjong-seiseki-sender/GameResult.swift
+++ b/Mahjong-seiseki-sender/GameResult.swift
@@ -7,17 +7,20 @@
 
 import Foundation
 
-struct GameResult: APIParameterConvertible {
+struct GameResult: APIParameterConvertible, Identifiable {
+    var id: String { "\(timeStamp) \(description)" }
+    
+    var timeStamp: Date
     var description: String
-    var point: Int
-    var rank: Int
+    var point: Float
+    var rank: Rank
     var rule: Rule
 
     func toDictionary() -> [String : Any] {
         return [
             "description": description,
             "point": point,
-            "rank": rank,
+            "rank": rank.rawValue,
             "rule": rule.rawValue
         ]
     }

--- a/Mahjong-seiseki-sender/GameResult.swift
+++ b/Mahjong-seiseki-sender/GameResult.swift
@@ -8,21 +8,39 @@
 import Foundation
 
 struct GameResult: APIParameterConvertible, Identifiable {
-    var id: String { "\(timeStamp) \(description)" }
-    
-    var timeStamp: Date
-    var description: String
-    var point: Float
-    var rank: Rank
-    var rule: Rule
+    let timeStamp: Date
+    let description: String
+    let point: Point
+    let rank: Rank
+    let rule: Rule
 
+    var id: Date { timeStamp }
+
+    /// APIで送信するためのdictionary
     func toDictionary() -> [String : Any] {
         return [
-            "description": description,
-            "point": point,
+            // timestampとdesctiptionがスペースが入ってjsonエンコードに失敗する可能性があるので""でくくっておく
+            "timeStamp": "\(timeStamp)",
+            "description": "\(description)",
+            "point": point.value,
             "rank": rank.rawValue,
             "rule": rule.rawValue
         ]
+    }
+}
+
+// プラスの場合+、マイナスの場合▲の記号をつけるようにする
+struct Point {
+    let value: Float
+    var signedString: String {
+        let formatter = NumberFormatter()
+        formatter.positivePrefix = "+"
+        formatter.negativePrefix = "▲"
+        return formatter.string(from: NSNumber(value: value)) ?? "\(value)"
+    }
+    
+    init(value: Float) {
+        self.value = value
     }
 }
 

--- a/Mahjong-seiseki-sender/Rank.swift
+++ b/Mahjong-seiseki-sender/Rank.swift
@@ -8,10 +8,17 @@
 import Foundation
 
 enum Rank: Int, CaseIterable, Identifiable {
+    var id: Int { rawValue }
+    
     case first = 1
     case second = 2
     case third = 3
     case forth = 4
+}
 
-    var id: Int { rawValue }
+extension Rank {
+    /// 1着、2着、3着、4着いずれかのStringを返す
+    func toString() -> String {
+        return "\(self.rawValue)着"
+    }
 }

--- a/Mahjong-seiseki-sender/Rule.swift
+++ b/Mahjong-seiseki-sender/Rule.swift
@@ -5,11 +5,31 @@
 //  Created by Shunsuke Kamada on 2024/12/10.
 //
 
+import Foundation
+
 /**
  * 記録するゲームのルール。
  */
 enum Rule: String, CaseIterable, Identifiable {
     var id: String { rawValue }
+
+    var shortHanded: String {
+        switch self {
+        case .M_REAGUE: return "Mルール"
+        case .SAIKOUISEN: return "最高位ﾙｰﾙ"
+        case .SAIKOUISEN_CLASSIC: return "最高位ｸﾗｼｯｸ"
+        case .RENMEI: return "連盟ﾙｰﾙ"
+        case .WRC: return "WRCﾙｰﾙ"
+        case .WRC_R: return "WRC-Rﾙｰﾙ"
+        case .KYOKAI: return "協会ﾙｰﾙ"
+        case .RMU_A: return "RMU-Aﾙｰﾙ"
+        case .RMU_B: return "RMU-Bﾙｰﾙ"
+        case .RMU_M: return "RMU-Mﾙｰﾙ"
+        case .MU: return "MUﾙｰﾙ"
+        case .MU_CUP: return "MU杯ﾙｰﾙ"
+        case .MU_TOUR: return "MUツアーﾙｰﾙ"
+        }
+    }
 
     // Mリーグ
     /** 赤あり、10-30、オカあり */
@@ -54,4 +74,3 @@ enum Rule: String, CaseIterable, Identifiable {
     /** 赤なし、テンパイ料なし、本場なし、4-12 */
     case MU_TOUR = "ツアーランキングルール"
 }
-


### PR DESCRIPTION
- 送信履歴のViewを追加
  - 削除もできるようにした
  - 平均順位・合計のポイントを表示させるようにした
- 送信時のAPI成功・失敗のアイコンが表示されるようにした

https://github.com/user-attachments/assets/c633d409-062c-4617-b326-0a6f7d3b1d71

